### PR TITLE
Fix animation export logic and add support for dumping animations via mdlconvert

### DIFF
--- a/src/MercuryEngine.Data.Converters/Bcmdl/GltfExporter.cs
+++ b/src/MercuryEngine.Data.Converters/Bcmdl/GltfExporter.cs
@@ -94,7 +94,7 @@ public sealed class GltfExporter(IGameAssetResolver? assetResolver = null) : IDi
 
 			if (!ArmatureNodeCacheByCrc.TryGetValue(boneTrack.BoneName, out var boneNode))
 			{
-				Warn($"Animation track {thisIndex} referenced unknown bone \"{boneTrack.BoneName}\"");
+				Warn($"Animation track {thisIndex} of \"{animationName}\" referenced unknown bone \"{boneTrack.BoneName}\"");
 				continue;
 			}
 

--- a/src/MercuryEngine.Data.Converters/Utility/CubicHermiteSpline.cs
+++ b/src/MercuryEngine.Data.Converters/Utility/CubicHermiteSpline.cs
@@ -1,0 +1,155 @@
+﻿using System.Diagnostics;
+using System.Numerics;
+
+namespace MercuryEngine.Data.Converters.Utility;
+
+public class CubicHermiteSpline
+{
+	private const float Tolerance = 1e-5f;
+
+	private readonly SplinePoint[] points;
+	private readonly float[]       times;
+
+	public CubicHermiteSpline(params IEnumerable<SplinePoint> points)
+		: this(points.ToArray()) { }
+
+	public CubicHermiteSpline(params SplinePoint[] points)
+	{
+		this.points = points;
+		this.times = new float[points.Length];
+
+		var minTime = float.PositiveInfinity;
+		var maxTime = float.NegativeInfinity;
+		var prevTime = float.NegativeInfinity;
+
+		for (var i = 0; i < points.Length; i++)
+		{
+			var time = points[i].Time;
+
+			minTime = float.Min(minTime, time);
+			maxTime = float.Max(maxTime, time);
+
+			if (time < prevTime)
+				throw new ArgumentException($"Points must be specified in ascending time order. " +
+											$"Point {i} had a smaller time value than point {i - 1}.",
+											nameof(points));
+
+			this.times[i] = time;
+			prevTime = time;
+		}
+
+		MinimumTime = minTime;
+		MaximumTime = maxTime;
+	}
+
+	public IReadOnlyList<SplinePoint> Points => this.points;
+
+	public IReadOnlyList<float> PointTimes => this.times;
+
+	public float MinimumTime { get; }
+	public float MaximumTime { get; }
+
+	public float GetValueAt(float time)
+	{
+		// Edge cases first
+		if (Math.Abs(time - MinimumTime) <= Tolerance)
+			return this.points[0].Value;
+		if (Math.Abs(time - MaximumTime) <= Tolerance)
+			return this.points[^1].Value;
+
+		var k = GetTimeIndex(time);
+		var time0 = this.times[k];
+		var time1 = this.times[k + 1];
+		var range = time1 - time0;
+		var t = ( time - time0 ) / range;
+
+		var (_, v0, m0) = this.points[k];
+		var (_, v1, m1) = this.points[k + 1];
+
+		var basisVector = GetValueBasisVector(t);
+		var valuesVector = new Vector4(v0, m0, v1, m1);
+		var rangeVector = new Vector4(1, range, 1, range);
+
+		return Vector4.Dot(basisVector, valuesVector * rangeVector);
+	}
+
+	public float GetDerivativeAt(float time)
+	{
+		// Edge cases first
+		if (Math.Abs(time - MinimumTime) <= Tolerance)
+			return this.points[0].Derivative;
+		if (Math.Abs(time - MaximumTime) <= Tolerance)
+			return this.points[^1].Derivative;
+
+		var k = GetTimeIndex(time);
+		var time0 = this.times[k];
+		var time1 = this.times[k + 1];
+		var range = time1 - time0;
+		var t = ( time - time0 ) / range;
+
+		var (_, v0, m0) = this.points[k];
+		var (_, v1, m1) = this.points[k + 1];
+
+		var basisVector = GetDerivativeBasisVector(t);
+		var valuesVector = new Vector4(v0, m0, v1, m1);
+		var rangeVector = new Vector4(1, range, 1, range);
+
+		return Vector4.Dot(basisVector, valuesVector * rangeVector);
+	}
+
+	private int GetTimeIndex(float time)
+	{
+		ArgumentOutOfRangeException.ThrowIfLessThan(time, MinimumTime);
+		ArgumentOutOfRangeException.ThrowIfGreaterThan(time, MaximumTime);
+
+		// At this point we know that "time" MUST BE within our domain
+
+		// If this returns a non-negative number, "time" is on one of our control points.
+		// If it returns a negative number, the bitwise complement of that number is the
+		// index of the control point AFTER "time", so we need to take (bitwise complement
+		// - 1) to get the control point BEFORE "time".
+		var k = Array.BinarySearch(this.times, time);
+
+		if (k < 0)
+			k = ~k - 1;
+
+		Debug.Assert(k >= 0, "Time out-of-range");
+		Debug.Assert(k < this.points.Length - 1, "Time out-of-range");
+
+		return k;
+	}
+
+	#region Basis Helpers
+
+	private static readonly Matrix4x4 ValueBasisMatrix = new(
+		2, 1, -2, 1,
+		-3, -2, 3, -1,
+		0, 1, 0, 0,
+		1, 0, 0, 0
+	);
+
+	private static readonly Matrix4x4 DerivativeBasisMatrix = new(
+		0, 0, 0, 0,
+		6, 3, -6, 3,
+		-6, 0, 6, -2,
+		0, -2, 0, 0
+	);
+
+	private static Vector4 GetValueBasisVector(float t)
+	{
+		var t2 = t * t;
+		var t3 = t2 * t;
+
+		return Vector4.Transform(new Vector4(t3, t2, t, 1f), ValueBasisMatrix);
+	}
+
+	private static Vector4 GetDerivativeBasisVector(float t)
+	{
+		var t2 = t * t;
+		const float t3 = 0f; // We cheat because the first column of the matrix is all 0s - we don't need to compute t3 at all
+
+		return Vector4.Transform(new Vector4(t3, t2, t, 1f), DerivativeBasisMatrix);
+	}
+
+	#endregion
+}

--- a/src/MercuryEngine.Data.Converters/Utility/SplinePoint.cs
+++ b/src/MercuryEngine.Data.Converters/Utility/SplinePoint.cs
@@ -1,0 +1,3 @@
+﻿namespace MercuryEngine.Data.Converters.Utility;
+
+public readonly record struct SplinePoint(float Time, float Value, float Derivative);

--- a/src/MercuryEngine.Data.Core/MercuryEngine.Data.Core.csproj
+++ b/src/MercuryEngine.Data.Core/MercuryEngine.Data.Core.csproj
@@ -12,6 +12,7 @@
 
 	<ItemGroup>
 		<InternalsVisibleTo Include="MercuryEngine.Data" />
+		<InternalsVisibleTo Include="MercuryEngine.Data.Converters" />
 		<InternalsVisibleTo Include="MercuryEngine.Data.Definitions" />
 		<InternalsVisibleTo Include="MercuryEngine.Data.Tests" />
 	</ItemGroup>

--- a/src/MercuryEngine.Data/GameAssets/IGameAssetResolver.cs
+++ b/src/MercuryEngine.Data/GameAssets/IGameAssetResolver.cs
@@ -56,4 +56,7 @@ public interface IGameAssetResolver
 	/// A <see cref="GameAsset"/> instance representing the asset with the requested <paramref name="relativePath"/>.
 	/// </returns>
 	GameAsset GetAsset(string relativePath, string? assetIdOverride = null);
+
+	// TODO: Docs
+	IEnumerable<GameAsset> EnumerateAssets(string directory, Func<string, string>? assetIdTransformer = null);
 }

--- a/src/MercuryEngine.Data/Types/Bcmdl/Wrappers/ArmatureJoint.cs
+++ b/src/MercuryEngine.Data/Types/Bcmdl/Wrappers/ArmatureJoint.cs
@@ -29,4 +29,13 @@ public class ArmatureJoint(string name)
 		child.Parent = null;
 		return true;
 	}
+
+	public IEnumerable<ArmatureJoint> EnumerateSelfAndChildren()
+	{
+		yield return this;
+
+		foreach (var child in Children)
+		foreach (var descendent in child.EnumerateSelfAndChildren())
+			yield return descendent;
+	}
 }

--- a/src/MercuryEngine.Data/Types/Bcskla/AnimatableValue.cs
+++ b/src/MercuryEngine.Data/Types/Bcskla/AnimatableValue.cs
@@ -27,6 +27,8 @@ public class AnimatableValue : IBinaryField
 		}
 	}
 
+	public int ValueCount => IsConstant ? 1 : this.keyframeValues.Count;
+
 	internal ulong PointerBase { get; set; }
 
 	private ValueTrack ValueTrack { get; } = new();

--- a/src/MercuryEngine.Data/Types/Bcskla/KeyframeValue.cs
+++ b/src/MercuryEngine.Data/Types/Bcskla/KeyframeValue.cs
@@ -42,4 +42,10 @@ public struct KeyframeValue : IBinaryField
 		await writer.WriteAsync(Value, cancellationToken).ConfigureAwait(false);
 		await writer.WriteAsync(Rate, cancellationToken).ConfigureAwait(false);
 	}
+
+	public void Deconstruct(out float value, out float rate)
+	{
+		value = Value;
+		rate = Rate;
+	}
 }

--- a/tools/MercuryEngine.Data.Tools.ModelConverter/ExportCommand.cs
+++ b/tools/MercuryEngine.Data.Tools.ModelConverter/ExportCommand.cs
@@ -1,4 +1,5 @@
 ﻿using System.CommandLine;
+using System.Text.RegularExpressions;
 using MercuryEngine.Data.Converters.Bcmdl;
 using MercuryEngine.Data.Formats;
 using MercuryEngine.Data.GameAssets;
@@ -16,6 +17,7 @@ internal class ExportCommand : BaseCommand
 		var inputModelPath = result.GetRequiredValue(Args.Export.InputModelPath);
 		var outputModelPath = result.GetRequiredValue(Args.Export.OutputModelPath);
 		var outputFormat = result.GetValue(Args.Export.OutputFormat);
+		var animationDirectories = result.GetValue(Args.Export.AnimationDirectories);
 
 		// Get the model to be exported
 		var assetResolver = new DefaultGameAssetResolver(romFsPath);
@@ -56,11 +58,71 @@ internal class ExportCommand : BaseCommand
 		var modelName = Path.GetFileNameWithoutExtension(inputModelPath);
 
 		exporter.LoadBcmdl(modelToExport, modelName);
+
+		if (animationDirectories is { Count: > 0 })
+			FindAndAttachAnimations(result, assetResolver, exporter);
+
 		exporter.ExportGltf(outputModelPath.FullName, binary: outputFormat == GltfFormat.Binary);
 
 		if (!quiet)
 			Console.WriteLine($"Exported model saved to {outputModelPath.FullName}");
 
 		return ExitCodes.Success;
+	}
+
+	private static void FindAndAttachAnimations(ParseResult result, IGameAssetResolver assetResolver, GltfExporter exporter)
+	{
+		var animationDirectories = result.GetValue(Args.Export.AnimationDirectories);
+		var animationNames = result.GetValue(Args.Export.AnimationNames);
+		var animationIncludeFilters = result.GetValue(Args.Export.AnimationIncludeFilters);
+		var animationExcludeFilters = result.GetValue(Args.Export.AnimationExcludeFilters);
+		var assetPredicate = GetGameAssetPredicate(".bcskla", animationNames, animationIncludeFilters, animationExcludeFilters);
+
+		if (animationDirectories is null)
+			return;
+
+		foreach (var asset in FindAnimationAssets(assetResolver, animationDirectories, assetPredicate))
+		{
+			var name = Path.GetFileNameWithoutExtension(asset.RelativePath);
+			var animation = asset.ReadAs<Bcskla>();
+
+			exporter.AttachAnimation(name, animation);
+		}
+	}
+
+	private static IEnumerable<GameAsset> FindAnimationAssets(IGameAssetResolver assetResolver, List<string> directories, Func<GameAsset, bool> assetPredicate)
+		=> directories.SelectMany(directory => assetResolver.EnumerateAssets(directory)).Where(assetPredicate);
+
+	private static Func<GameAsset, bool> GetGameAssetPredicate(string extension, List<string>? names, List<string>? includeFilters, List<string>? excludeFilters)
+	{
+		if (names is { Count: > 0 })
+		{
+			var namesSet = new HashSet<string>(names, StringComparer.OrdinalIgnoreCase);
+
+			return asset => {
+				if (!Path.GetExtension(asset.RelativePath).Equals(extension, StringComparison.OrdinalIgnoreCase))
+					return false;
+
+				return namesSet.Contains(Path.GetFileNameWithoutExtension(asset.RelativePath));
+			};
+		}
+
+		if (includeFilters is null or { Count: 0 } && excludeFilters is null or { Count: 0 })
+			// No filters - all assets with the desired extension are included
+			return asset => Path.GetExtension(asset.RelativePath).Equals(extension, StringComparison.OrdinalIgnoreCase);
+
+		var includePatterns = includeFilters?.Select(filter => new Regex(filter, RegexOptions.IgnoreCase)).ToList();
+		var excludePatterns = excludeFilters?.Select(filter => new Regex(filter, RegexOptions.IgnoreCase)).ToList();
+
+		return asset => {
+			if (!Path.GetExtension(asset.RelativePath).Equals(extension, StringComparison.OrdinalIgnoreCase))
+				return false;
+
+			var name = Path.GetFileNameWithoutExtension(asset.RelativePath);
+			var isIncluded = includePatterns is null or { Count: 0 } || includePatterns.Any(p => p.IsMatch(name));
+			var isExcluded = excludePatterns is { Count: > 0 } && excludePatterns.Any(p => p.IsMatch(name));
+
+			return isIncluded && !isExcluded;
+		};
 	}
 }


### PR DESCRIPTION
This PR fixes the animation export process so that it will correctly interpolate animation values when the keyframes of the different components of a property don't line up (e.g. there is a keyframe for "Position.X" but not "Position.Y" or "Position.Z", and keyframes need to be synthesized for Y/Z).

This PR also changes how empty/non-skinning joints are handled, ensuring that they are preserved as actual armature bones when imported into tools like Blender instead of plain empty objects.

Finally, mdlconvert was updated to include options for dumping animations during model export, taking advantage of the newly-fixed animation export system.